### PR TITLE
ignore rds now in R folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 .Rproj.user
-render_post/_book_meta.rds
+R/_book_meta.rds
 *.Rproj
 blogdown
 public


### PR DESCRIPTION
`_book_meta.rds` is now in R folder not render_post. 
Just updated the `.gitignore` for that.