### PR TITLE
Add edav.info/ to bookdown.org

### DIFF
--- a/R/staging.txt
+++ b/R/staging.txt
@@ -1,0 +1,1 @@
+http://edav.info/

--- a/R/staging.txt
+++ b/R/staging.txt
@@ -1,1 +1,1 @@
-http://edav.info/
+https://edav.info/


### PR DESCRIPTION
Wanting to get http://edav.info/ on bookdown.org listing page. 

Our repo: https://github.com/jtr13/EDAV

Thanks!