### PR TITLE
Add documentation to main menu?

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,28 +25,28 @@ footnotereturnlinkcontents = "↩"
     weight = 2
 [[menu.main]]
     name = "Documentation"
-    url = "https://bookdown.org/yihui/bookdown/"
-    weight = 2
+    url = "//bookdown.org/yihui/bookdown/"
+    weight = 3
 [[menu.main]]
     name = "Archive"
     url = "/archive/"
-    weight = 3
+    weight = 4
 [[menu.main]]
     name = "Tags"
     url = "/tags/"
-    weight = 4
+    weight = 5
 [[menu.main]]
     name = "Authors"
     url = "/authors/"
-    weight = 5
+    weight = 6
 [[menu.main]]
     name = "Contest"
     url = "/contest/"
-    weight = 6
+    weight = 7
 [[menu.main]]
     name = "Log in"
     url = "http://bookdown.org/connect/"
-    weight = 7
+    weight = 8
 
 [[menu.icons]]
     name = "Github"

--- a/config.toml
+++ b/config.toml
@@ -24,6 +24,10 @@ footnotereturnlinkcontents = "↩"
     url = "/about/"
     weight = 2
 [[menu.main]]
+    name = "Documentation"
+    url = "https://bookdown.org/yihui/bookdown/"
+    weight = 2
+[[menu.main]]
     name = "Archive"
     url = "/archive/"
     weight = 3


### PR DESCRIPTION
As a user looking for the documentation, I think that it would be convenient to have a prominent link to the documentation in the main menu at the top of the page.

Currently I have to scroll through a bit of text to find it. If there isn't enough room, I would propose removing 'Archive'? (or at least renaming it to something like 'library' or something that would indicate it contains a list of books).