### PR TITLE
add prefresher book to bookdown.org

### DIFF
--- a/R/staging.txt
+++ b/R/staging.txt
@@ -1,0 +1,1 @@
+https://iqss.github.io/prefresher/


### PR DESCRIPTION
It would be great to have this linked. the book was mentioned in the [bookdown contest](https://community.rstudio.com/t/bookdown-contest-submission-math-prefresher-for-political-scientists/15486). 
