### PR TITLE
Add rmarkdown cookbook to homepage

### DIFF
--- a/R/home.txt
+++ b/R/home.txt
@@ -16,3 +16,4 @@ https://rstudio-education.github.io/hopr/
 https://r-graphics.org/
 https://livebook.datascienceheroes.com/
 https://r-pkgs.org/
+https://bookdown.org/yihui/rmarkdown-cookbook/


### PR DESCRIPTION
As it is soon to be published I think we can pin it to home page on bookdown.org. What do you think ? 