### PR TITLE
Tweaks to support books with bs4_book() template

### DIFF
--- a/R/create-md.R
+++ b/R/create-md.R
@@ -79,8 +79,17 @@ cover_list = list(
 
 # the length of search_index.json indicates the length of the book
 book_length = function(url) {
-  x = httr::headers(httr::HEAD(paste0(url, 'search_index.json')))$`content-length`
-  if (length(x) == 0) 0 else as.numeric(x)
+  search_file = c("search_index.json", "search.json")
+  # use first json found
+  for (s in search_file) {
+    head = httr::HEAD(paste0(url, s))
+    if (httr::status_code(head) >= 400) next
+    if (length(head) == 0) return(0)
+    x = httr::headers(head)$`content-length`
+    return(if (length(x) == 0) 0 else as.numeric(x))
+  }
+  # no json found
+  0L
 }
 
 match_tags = function(text) {

--- a/R/create-md.R
+++ b/R/create-md.R
@@ -120,6 +120,11 @@ get_book_meta = function(url, date = NA) {
   title = xml_find(html, './/title')
   if (length(title) == 0) return()
   title = xml_text(title)
+  # Chapter name can be prepended to book title in other book format.
+  # It happens due to `bookdown::prepend_chapter_title()`. 
+  # See https://github.com/rstudio/bookdown.org/issues/62
+  # TODO: adapt if change upstream.
+  title = gsub('^.*\\|\\s*([^|]*)$', '\\1', title)
   if (title == '') return()
 
   description = xml_find(html, './/meta[@name="description"]')


### PR DESCRIPTION
This take into account #62 

- Several json file are looked for
- Book title is extracted also from title using `chapter name | book title`

Other accommodation would be best handle by making some evolution to `bs4_book()`