### PR TITLE
Update link for Understanding the Whole Child

### DIFF
--- a/R/staging.txt
+++ b/R/staging.txt
@@ -1,0 +1,9 @@
+Hi!
+
+Would it be possible to update the link for Understanding the Whole Child: Prenatal Development through Adolescence (Paris et al., added 2021-06-08)?
+
+New link: https://bookdown.org/nathalieyuen/understanding-the-whole-child/
+
+Thanks for your help!
+
+(Hope I'm doing this right.)

--- a/R/staging.txt
+++ b/R/staging.txt
@@ -1,9 +1,2 @@
-Hi!
-
-Would it be possible to update the link for Understanding the Whole Child: Prenatal Development through Adolescence (Paris et al., added 2021-06-08)?
-
+Understanding the Whole Child: Prenatal Development through Adolescence (Paris et al., added 2021-06-08)
 New link: https://bookdown.org/nathalieyuen/understanding-the-whole-child/
-
-Thanks for your help!
-
-(Hope I'm doing this right.)


### PR DESCRIPTION
Hi!

Would it be possible to update the link for Understanding the Whole Child: Prenatal Development through Adolescence (Paris et al., added 2021-06-08)?

New link: https://bookdown.org/nathalieyuen/understanding-the-whole-child/

Thanks for your help!

(Hope I'm doing this right.)